### PR TITLE
Clarify purpose of Assignments page

### DIFF
--- a/assignments.md
+++ b/assignments.md
@@ -17,12 +17,11 @@ various services that we will use during the semester including
 [Cloud9](https://c9.io/). These assignments will be completed
 individually and will be submitted through the class website.
 
-## Submitting through the class website
+## Assignment instructions
 
-On the class website there is an "Assignments" link. From there, you
+On the class website (either http://660.mba or http://656.mba) there is an "Assignments" link. From there, you
 can browse individual assignments including instructions for completing
-and submitting each assignment. Most persons will want to submit their
-assignments through the class website.
+and submitting each assignment.
 
 ## Submitting through the class API
 


### PR DESCRIPTION
If I remember correctly, in CS 213 the Assignments page on cpsc213.io had instructions on how to complete the assignment (where the GitHub starter repo is, helpful documentation links, how to submit via API, etc.) but all the actual submission itself was via API.

Currently, assignments.md has 2 headings ("Submitting through the class website" and "Submitting through the class API") which makes it sound like students can choose between 2 different, but equally valid ways of submitting an assignment. I think the proposed changes make it clear a) what the Assignments page is for, and b) that assignments still need to be submitted via API.

**If class policy is changing for 656 vs 213, please ignore my changes!!**