### PR TITLE
Add rough percentages for grade weights of different activities

### DIFF
--- a/grading.md
+++ b/grading.md
@@ -12,14 +12,14 @@ generally, the instructors will be constantly tweaking our class to maximize
 our learning and enjoyment. At the
 end of the semester, we suspect the grades will be roughly as follows.
 
-- Individual assignments: roughly 210 points. These are the technical assignments you will complete, which are front-loaded at the beginning of the course.
+- Individual assignments: roughly 210 points (~25%). These are the technical assignments you will complete, which are front-loaded at the beginning of the course.
 - Quizzes: 13pts each. Expect roughly 20 over the course of the semester.
   Your lowest five quizzes will be dropped automatically and the total contribution
-  of quizzes to the points in the class should be roughly 200pts.
+  of quizzes to the points in the class should be roughly 200pts (~23.5%).
   See the section on [quizzes](quizzes.md).
-- Class Project: roughly 215pts over the course of the semester, including the final presentation.
-- Two exams: 60pts each.
-- Class participation: roughly 100pts. Class participation is divided roughly
+- Class Project: roughly 215pts (~25.5%) over the course of the semester, including the final presentation.
+- Two exams: 60pts (~7%) each.
+- Class participation: roughly 100pts (~12%). Class participation is divided roughly
   equally between in-class participation, online participation through
   the class Q&A system. The TAs will keep track of participation in class.
   _It is your responsibility to ensure the TAs record that you attended class


### PR DESCRIPTION
I think having the relative importance (i.e X %) of a task is more important to a student looking at a class syllabus than the absolute importance (i.e X points)